### PR TITLE
Fix mapZerocoinSupply recalculation

### DIFF
--- a/src/consensus/zerocoin_verify.cpp
+++ b/src/consensus/zerocoin_verify.cpp
@@ -149,8 +149,9 @@ bool ContextualCheckZerocoinSpend(const CTransaction& tx, const libzerocoin::Coi
 
 bool ContextualCheckZerocoinSpendNoSerialCheck(const CTransaction& tx, const libzerocoin::CoinSpend* spend, int nHeight, const uint256& hashBlock)
 {
+    const Consensus::Params& consensus = Params().GetConsensus();
     //Check to see if the zXNK is properly signed
-    if (nHeight >= Params().GetConsensus().height_start_ZC_SerialsV2) {
+    if (nHeight >= consensus.height_start_ZC_SerialsV2) {
         try {
             if (!spend->HasValidSignature())
                 return error("%s: V2 zXNK spend does not have a valid signature\n", __func__);
@@ -174,7 +175,7 @@ bool ContextualCheckZerocoinSpendNoSerialCheck(const CTransaction& tx, const lib
     bool fUseV1Params = spend->getCoinVersion() < libzerocoin::PrivateCoin::PUBKEY_VERSION;
 
     //Reject serial's that are not in the acceptable value range
-    if (!spend->HasValidSerial(Params().GetConsensus().Zerocoin_Params(fUseV1Params)))  {
+    if (!spend->HasValidSerial(consensus.Zerocoin_Params(fUseV1Params)))  {
         // Up until this block our chain was not checking serials correctly..
         if (!isBlockBetweenFakeSerialAttackRange(nHeight))
             return error("%s : zXNK spend with serial %s from tx %s is not in valid range\n", __func__,
@@ -218,15 +219,16 @@ void AddWrappedSerialsInflation()
     uiInterface.ShowProgress("", 100);
 }
 
-bool RecalculateXNKSupply(int nHeightStart)
+bool RecalculateXNKSupply(int nHeightStart, bool fSkipZxnk)
 {
+    const Consensus::Params& consensus = Params().GetConsensus();
     const int chainHeight = chainActive.Height();
     if (nHeightStart > chainHeight)
         return false;
 
     CBlockIndex* pindex = chainActive[nHeightStart];
     CAmount nSupplyPrev = pindex->pprev->nMoneySupply;
-    if (nHeightStart == Params().GetConsensus().height_start_ZC)
+    if (nHeightStart == consensus.height_start_ZC)
         nSupplyPrev = CAmount(5449796547496199);
 
     uiInterface.ShowProgress(_("Recalculating XNK supply..."), 0);
@@ -271,8 +273,13 @@ bool RecalculateXNKSupply(int nHeightStart)
         pindex->nMoneySupply = nSupplyPrev + nValueOut - nValueIn;
         nSupplyPrev = pindex->nMoneySupply;
 
+        // Rewrite zxnk supply too
+        if (!fSkipZxnk && pindex->nHeight >= consensus.height_start_ZC) {
+            UpdateZXNKSupply(block, pindex, true);
+        }
+
         // Add fraudulent funds to the supply and remove any recovered funds.
-        if (pindex->nHeight == Params().GetConsensus().height_ZC_RecalcAccumulators) {
+        if (pindex->nHeight == consensus.height_ZC_RecalcAccumulators) {
             const CAmount nInvalidAmountFiltered = 0*COIN;    //Amount of invalid coins filtered through exchanges, that should be considered valid
             LogPrintf("%s : Original money supply=%s\n", __func__, FormatMoney(pindex->nMoneySupply));
 
@@ -286,6 +293,9 @@ bool RecalculateXNKSupply(int nHeightStart)
 
         assert(pblocktree->WriteBlockIndex(CDiskBlockIndex(pindex)));
 
+        // Stop if shutdown was requested
+        if (ShutdownRequested()) return false;
+
         if (pindex->nHeight < chainHeight)
             pindex = chainActive.Next(pindex);
         else
@@ -297,31 +307,24 @@ bool RecalculateXNKSupply(int nHeightStart)
 
 bool UpdateZXNKSupply(const CBlock& block, CBlockIndex* pindex, bool fJustCheck)
 {
-    std::list<CZerocoinMint> listMints;
-    bool fFilterInvalid = pindex->nHeight >= Params().GetConsensus().height_ZC_RecalcAccumulators;
-    BlockToZerocoinMintList(block, listMints, fFilterInvalid);
-    std::list<libzerocoin::CoinDenomination> listSpends = ZerocoinSpendListFromBlock(block, fFilterInvalid);
+    const Consensus::Params& consensus = Params().GetConsensus();
+    if (pindex->nHeight < consensus.height_start_ZC)
+        return true;
 
-    // Initialize zerocoin supply to the supply from previous block
-    if (pindex->pprev && pindex->pprev->GetBlockHeader().nVersion > 3) {
-        for (auto& denom : libzerocoin::zerocoinDenomList) {
-            pindex->mapZerocoinSupply.at(denom) = pindex->pprev->GetZcMints(denom);
-        }
-    }
+    //Reset the supply to previous block
+    pindex->mapZerocoinSupply = pindex->pprev->mapZerocoinSupply;
 
-    // Track zerocoin money supply
-    CAmount nAmountZerocoinSpent = 0;
-    if (pindex->pprev) {
+    //Add mints to zXNK supply (mints are forever disabled after last checkpoint)
+    if (pindex->nHeight < consensus.height_last_ZC_AccumCheckpoint) {
+        std::list<CZerocoinMint> listMints;
         std::set<uint256> setAddedToWallet;
-        for (auto& m : listMints) {
-            libzerocoin::CoinDenomination denom = m.GetDenomination();
-            pindex->mapZerocoinSupply.at(denom)++;
-
+        BlockToZerocoinMintList(block, listMints, true);
+        for (const auto& m : listMints) {
+            pindex->mapZerocoinSupply.at(m.GetDenomination())++;
             //Remove any of our own mints from the mintpool
             if (!fJustCheck && pwalletMain) {
                 if (pwalletMain->IsMyMint(m.GetValue())) {
                     pwalletMain->UpdateMint(m.GetValue(), pindex->nHeight, m.GetTxHash(), m.GetDenomination());
-
                     // Add the transaction to the wallet
                     for (auto& tx : block.vtx) {
                         uint256 txid = tx.GetHash();
@@ -338,29 +341,28 @@ bool UpdateZXNKSupply(const CBlock& block, CBlockIndex* pindex, bool fJustCheck)
                 }
             }
         }
-
-        for (auto& denom : listSpends) {
-            pindex->mapZerocoinSupply.at(denom)--;
-            nAmountZerocoinSpent += libzerocoin::ZerocoinDenominationToAmount(denom);
-
-            // zerocoin failsafe
-            if (pindex->GetZcMints(denom) < 0)
-                return error("Block contains zerocoins that spend more than are in the available supply to spend");
-        }
     }
 
-    for (auto& denom : libzerocoin::zerocoinDenomList)
-        LogPrint("zero", "%s coins for denomination %d pubcoin %s\n", __func__, denom, pindex->mapZerocoinSupply.at(denom));
+    //Remove spends from zXNK supply
+    std::list<libzerocoin::CoinDenomination> listDenomsSpent = ZerocoinSpendListFromBlock(block, true);
+    for (const auto& denom : listDenomsSpent) {
+        pindex->mapZerocoinSupply.at(denom)--;
+        // zerocoin failsafe
+        if (pindex->mapZerocoinSupply.at(denom) < 0)
+            return error("Block contains zerocoins that spend more than are in the available supply to spend");
+    }
 
     // Update Wrapped Serials amount
     // A one-time event where only the zXNK supply was off (due to serial duplication off-chain on main net)
-    const Consensus::Params& consensus = Params().GetConsensus();
     if (Params().NetworkID() == CBaseChainParams::MAIN && pindex->nHeight == consensus.height_last_ZC_WrappedSerials + 1
             && pindex->GetZerocoinSupply() < consensus.ZC_WrappedSerialsSupply + GetWrapppedSerialInflationAmount()) {
-        for (auto denom : libzerocoin::zerocoinDenomList) {
+        for (const auto& denom : libzerocoin::zerocoinDenomList)
             pindex->mapZerocoinSupply.at(denom) += GetWrapppedSerialInflation(denom);
-        }
     }
+
+    for (const auto& denom : libzerocoin::zerocoinDenomList)
+        LogPrint("zero", "%s coins for denomination %d pubcoin %s\n", __func__, denom, pindex->mapZerocoinSupply.at(denom));
+
     return true;
 }
 

--- a/src/consensus/zerocoin_verify.h
+++ b/src/consensus/zerocoin_verify.h
@@ -22,7 +22,7 @@ bool CheckPublicCoinSpendVersion(int version);
 bool ContextualCheckZerocoinSpend(const CTransaction& tx, const libzerocoin::CoinSpend* spend, int nHeight, const uint256& hashBlock);
 bool ContextualCheckZerocoinSpendNoSerialCheck(const CTransaction& tx, const libzerocoin::CoinSpend* spend, int nHeight, const uint256& hashBlock);
 void AddWrappedSerialsInflation();
-bool RecalculateXNKSupply(int nHeightStart);
+bool RecalculateXNKSupply(int nHeightStart), bool fSkipZxnk = true);
 bool UpdateZXNKSupply(const CBlock& block, CBlockIndex* pindex, bool fJustCheck);
 CAmount GetInvalidUTXOValue();
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -5,7 +5,7 @@
 // Copyright (c) 2013-2014 The NovaCoin Developers
 // Copyright (c) 2014-2018 The BlackCoin Developers
 // Copyright (c) 2015-2020 The PIVX developers
-// Copyright (c) 2020 The EncoCoin developers
+// Copyright (c) 2020 	   The EncoCoin developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -1552,7 +1552,7 @@ bool AppInit2()
                 // Recalculate money supply for blocks that are impacted by accounting issue after zerocoin activation
                 if (GetBoolArg("-reindexmoneysupply", false) || reindexZerocoin) {
                     // Recalculate from the zerocoin activation or from scratch.
-                    RecalculateXNKSupply(reindexZerocoin ? consensus.height_start_ZC : 1);
+                    RecalculateXNKSupply((reindexZerocoin ? consensus.height_start_ZC : 1), false);
                 }
 
                 if (!fReindex) {


### PR DESCRIPTION
ZXNK supply recalculation shouldn't be needed in the first place, if the client is syncing from scratch and correctly filtering invalid mints.
So, instead of restoring RecalculateZXNKMinted/RecalculateZXNKSpent, this PR does 2 things:

    fixes UpdateZXNKSupply filtering the invalid mints/spends since the start of zerocoin (not only after Zerocoin_Block_RecalculateAccumulators). So, syncing from scratch doesn not trigger any recalculation at the next startup.

    inserts a call to UpdateZXNKSupply directly in RecalculateXNKSupply, to be used during init, e.g. by those clients updating from old versions (with wrong supply in the index), or when using -reindexmoneysupply.
    This removes the additional I/O operations that were originally required with RecalculateZXNKMinted and RecalculateZXNKSpent (as blocks are already read inside RecalculateXNKSupply, and the relative indexes also already updated there).